### PR TITLE
IVE-165: Reduce UART speed to avoid loss of characters when talking t…

### DIFF
--- a/thingy9151lite_nrf9151_app/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/thingy9151lite_nrf9151_app/boards/nrf9151dk_nrf9151_ns.overlay
@@ -61,3 +61,8 @@
 &gd25wb256 {
 	status = "okay";
 };
+
+&uart0 {
+       status = "okay";
+       current-speed = <38400>;
+};

--- a/thingy9151lite_nrf9151_app/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/thingy9151lite_nrf9151_app/boards/nrf9161dk_nrf9161_ns.overlay
@@ -66,6 +66,11 @@
 	status = "okay";
 };
 
+&uart0 {
+	status = "okay";
+	current-speed = <38400>;
+};
+
 &uart1 {
 	status = "okay";
 #if 0 /* TBD - the app hangs with hw-flow-control enabled */


### PR DESCRIPTION
Workaround to avoid missing characters in the terminal program run within VM.

Applied to nrf9161dk_nrf9161_ns and nrf9151dk_nrf9151_ns

I've run jesd216 sample and nrf-app with this settings and does not observe lost characters.